### PR TITLE
Update service pages with translation

### DIFF
--- a/Guide project/src/App.tsx
+++ b/Guide project/src/App.tsx
@@ -19,6 +19,7 @@ const ArticlePage   = lazy(() => import('./pages/ArticlePage'));
 const AuthPage      = lazy(() => import('./pages/Auth'));
 const DashboardPage = lazy(() => import('./pages/DashboardPage'));
 const VerifyEmailPage = lazy(() => import('./pages/VerifyEmailPage'));
+const ServicePage   = lazy(() => import('./pages/ServicePage'));
 
 const Loading = () => <div>Loading...</div>;
 
@@ -70,6 +71,7 @@ export default function App() {
             <Route index element={<Suspense fallback={<Loading />}> <LandingPage /> </Suspense>} />
             <Route path="blog" element={<Suspense fallback={<Loading />}> <Blog /> </Suspense>} />
             <Route path="blog/:slug" element={<Suspense fallback={<Loading />}> <ArticlePage /> </Suspense>} />
+            <Route path="services/:serviceId" element={<Suspense fallback={<Loading />}> <ServicePage /> </Suspense>} />
           </Route>
 
           {/* Auth */}

--- a/Guide project/src/components/sections/Services.tsx
+++ b/Guide project/src/components/sections/Services.tsx
@@ -2,36 +2,41 @@ import React from 'react';
 import { Brain, Database, LineChart, ChevronRight } from 'lucide-react';
 import Card from '../ui/Card';
 import Button from '../ui/Button';
-import { useText } from '../../hooks/useText'; // Ajusta si la ruta es distinta
+import { Link } from 'react-router-dom';
+import { useText } from '../../hooks/useText';
 
 interface ServiceCardProps {
   icon: React.ReactNode;
   title: string;
   description: string;
+  slug: string;
   color: 'purple' | 'info' | 'success';
 }
 
-const ServiceCard: React.FC<ServiceCardProps> = ({ icon, title, description, color }) => {
+const ServiceCard: React.FC<ServiceCardProps> = ({ icon, title, description, slug, color }) => {
+  const { common } = useText();
   return (
-    <Card className="p-8">
-      <div
-        className={`w-12 h-12 ${
-          color === 'purple'
-            ? 'text-purple-primary'
-            : color === 'info'
-            ? 'text-status-info'
-            : 'text-status-success'
-        } mb-6`}
-      >
-        {icon}
-      </div>
-      <h3 className="text-xl font-bold text-text-primary mb-4">{title}</h3>
-      <p className="text-text-secondary mb-6">{description}</p>
-      <Button variant="text" color={color}>
-        Learn More
-        <ChevronRight className="w-4 h-4" />
-      </Button>
-    </Card>
+    <Link to={`/services/${slug}`} className="block group">
+      <Card className="p-8">
+        <div
+          className={`w-12 h-12 ${
+            color === 'purple'
+              ? 'text-purple-primary'
+              : color === 'info'
+                ? 'text-status-info'
+                : 'text-status-success'
+          } mb-6`}
+        >
+          {icon}
+        </div>
+        <h3 className="text-xl font-bold text-text-primary mb-4 group-hover:text-purple-primary transition-colors">{title}</h3>
+        <p className="text-text-secondary mb-6">{description}</p>
+        <Button variant="text" color={color}>
+          {common.learnMore}
+          <ChevronRight className="w-4 h-4" />
+        </Button>
+      </Card>
+    </Link>
   );
 };
 
@@ -41,20 +46,23 @@ const Services: React.FC = () => {
   const serviceData = [
     {
       icon: <Brain className="w-full h-full" />,
-      title: services.ai,
-      description: services.aiDesc,
+      title: services.dxia,
+      description: services.dxiaDesc,
+      slug: 'dx-ia-360',
       color: 'purple' as const,
     },
     {
       icon: <Database className="w-full h-full" />,
-      title: services.data,
-      description: services.dataDesc,
+      title: services.copilot,
+      description: services.copilotDesc,
+      slug: 'co-pilot-ai',
       color: 'info' as const,
     },
     {
       icon: <LineChart className="w-full h-full" />,
-      title: services.predictive,
-      description: services.predictiveDesc,
+      title: services.sprint,
+      description: services.sprintDesc,
+      slug: 'sprint-ia-90',
       color: 'success' as const,
     },
   ];
@@ -71,6 +79,7 @@ const Services: React.FC = () => {
             icon={service.icon}
             title={service.title}
             description={service.description}
+            slug={service.slug}
             color={service.color}
           />
         ))}

--- a/Guide project/src/hooks/useText.ts
+++ b/Guide project/src/hooks/useText.ts
@@ -14,12 +14,12 @@ export const useText = () => {
     },
     services: {
       title: t('services_title'),
-      ai: t('service_ai'),
-      aiDesc: t('service_ai_desc'),
-      data: t('service_data'),
-      dataDesc: t('service_data_desc'),
-      predictive: t('service_predictive'),
-      predictiveDesc: t('service_predictive_desc'),
+      dxia: t('service_dx_ai360'),
+      dxiaDesc: t('service_dx_ai360_desc'),
+      copilot: t('service_copilot'),
+      copilotDesc: t('service_copilot_desc'),
+      sprint: t('service_sprint_ia90'),
+      sprintDesc: t('service_sprint_ia90_desc'),
     },
     cases: {
       title: t('cases_title'),
@@ -41,6 +41,13 @@ export const useText = () => {
       back: t('back_to_articles'),
       notFound: t('article_not_found'),
       error: t('article_error'),
+    },
+    servicePage: {
+      notFound: t('service_not_found'),
+    },
+    common: {
+      learnMore: t('learn_more'),
+      backHome: t('back_home'),
     },
   };
 };

--- a/Guide project/src/locales/en/translation.json
+++ b/Guide project/src/locales/en/translation.json
@@ -6,13 +6,13 @@
   "hero_button_secondary": "Check Our Blog",
   "hero_ai_partners": "We collaborate with the world's most innovative AI companies",
 
-  "services_title": "Our Solutions",
-  "service_ai": "AI Solutions",
-  "service_ai_desc": "Custom AI models tailored to your specific business needs and challenges.",
-  "service_data": "Data Processing",
-  "service_data_desc": "Advanced data processing and analytics to uncover valuable insights.",
-  "service_predictive": "Predictive Analytics",
-  "service_predictive_desc": "Future-proof your decisions with our predictive analytics solutions.",
+  "services_title": "Our Services",
+  "service_dx_ai360": "Dx‑IA 360°",
+  "service_dx_ai360_desc": "3‑week assessment covering strategy, data, processes, technology and talent.",
+  "service_copilot": "Co‑Pilot AI",
+  "service_copilot_desc": "Strategic consulting, governance and 70‑20‑10 training to build in‑house capability.",
+  "service_sprint_ia90": "Sprint‑IA 90",
+  "service_sprint_ia90_desc": "1‑3 pilots ready for production in 90 days with RPA, generative AI and predictive analytics.",
 
   "cases_title": "Success Stories",
   "case_1_title": "Global Tech Leader",
@@ -34,5 +34,8 @@
   "nav_cases": "Case Studies",
   "nav_contact": "Contact",
   "nav_blog": "Blog",
-  "nav_cta": "Get Started"
+  "nav_cta": "Get Started",
+  "learn_more": "Learn More",
+  "back_home": "Back to Home",
+  "service_not_found": "Service not found."
 }

--- a/Guide project/src/locales/es/translation.json
+++ b/Guide project/src/locales/es/translation.json
@@ -6,13 +6,13 @@
   "hero_button_secondary": "Ver nuestro blog",
   "hero_ai_partners": "Colaboramos con las empresas de IA más innovadoras del mundo",
 
-  "services_title": "Nuestras Soluciones",
-  "service_ai": "Soluciones de IA",
-  "service_ai_desc": "Modelos de IA personalizados para las necesidades y retos de tu empresa.",
-  "service_data": "Procesamiento de datos",
-  "service_data_desc": "Análisis de datos avanzados para descubrir información valiosa.",
-  "service_predictive": "Analítica predictiva",
-  "service_predictive_desc": "Toma decisiones futuras con nuestra analítica predictiva.",
+  "services_title": "Nuestros Servicios",
+  "service_dx_ai360": "Dx‑IA 360°",
+  "service_dx_ai360_desc": "Diagnóstico de madurez digital e IA en cinco ejes en 3 semanas.",
+  "service_copilot": "Co‑Pilot AI",
+  "service_copilot_desc": "Consultoría estratégica, gobierno y capacitación 70‑20‑10.",
+  "service_sprint_ia90": "Sprint‑IA 90",
+  "service_sprint_ia90_desc": "Pilotos listos para producción en 90 días con RPA, IA generativa y analítica predictiva.",
 
   "cases_title": "Historias de Éxito",
   "case_1_title": "Líder Tecnológico Global",
@@ -34,5 +34,8 @@
     "nav_cases": "Casos de Éxito",
     "nav_contact": "Contacto",
     "nav_blog": "Blog",
-    "nav_cta": "Comenzar"  
+    "nav_cta": "Comenzar",
+    "learn_more": "Más información",
+    "back_home": "Volver al inicio",
+    "service_not_found": "Servicio no encontrado."
 }

--- a/Guide project/src/locales/fr/translation.json
+++ b/Guide project/src/locales/fr/translation.json
@@ -6,13 +6,13 @@
     "hero_button_secondary": "Voir notre blog",
     "hero_ai_partners": "Nous collaborons avec les entreprises d'IA les plus innovantes au monde",
   
-    "services_title": "Nos solutions",
-    "service_ai": "Solutions d'IA",
-    "service_ai_desc": "Modèles d'IA personnalisés pour les besoins et défis de votre entreprise.",
-    "service_data": "Traitement de données",
-    "service_data_desc": "Analyse avancée des données pour découvrir des informations précieuses.",
-    "service_predictive": "Analyse prédictive",
-    "service_predictive_desc": "Prenez des décisions éclairées avec notre analyse prédictive.",
+    "services_title": "Nos services",
+    "service_dx_ai360": "Dx‑IA 360°",
+    "service_dx_ai360_desc": "Diagnostic de maturité numérique et IA en cinq axes en 3 semaines.",
+    "service_copilot": "Co‑Pilot AI",
+    "service_copilot_desc": "Consultation stratégique, gouvernance et formation 70‑20‑10.",
+    "service_sprint_ia90": "Sprint‑IA 90",
+    "service_sprint_ia90_desc": "1‑3 pilotes prêts pour la production en 90 jours avec RPA, IA générative et analytique prédictive.",
   
     "cases_title": "Histoires de réussite",
     "case_1_title": "Leader technologique mondial",
@@ -34,6 +34,9 @@
     "nav_cases": "Études de cas",
     "nav_contact": "Contact",
     "nav_blog": "Blog",
-    "nav_cta": "Commencer"
+    "nav_cta": "Commencer",
+    "learn_more": "En savoir plus",
+    "back_home": "Retour à l'accueil",
+    "service_not_found": "Service non trouvé."
   }
   

--- a/Guide project/src/pages/ServicePage.tsx
+++ b/Guide project/src/pages/ServicePage.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { ArrowLeft } from 'lucide-react';
+import Card from '../components/ui/Card';
+import { useText } from '../hooks/useText';
+
+interface ServiceContent {
+  title: string;
+  summary: string;
+  sections: { heading: string; points: string[] }[];
+}
+
+const SERVICES: Record<string, ServiceContent> = {
+  'dx-ia-360': {
+    title: 'Dx‑IA 360° — Diagnóstico y hoja de ruta de Inteligencia Artificial',
+    summary:
+      'Evaluación de madurez digital e IA en cinco ejes (estrategia, datos, procesos, tecnología y talento) en tres semanas.',
+    sections: [
+      {
+        heading: 'Por qué importa',
+        points: [
+          'El 24% de las empresas cita la falta de conocimiento como barrera principal.',
+          'Sin datos y procesos mapeados, cualquier proyecto de IA fracasa.'
+        ]
+      },
+      {
+        heading: 'Entregables clave',
+        points: [
+          'Mapa de procesos y datos con scoring de automatización.',
+          'Quick‑wins de alto impacto (casos de uso ≤ 90 días, ROI ≥ 150%).',
+          'Business case financiero (capex/opex, TIR, pay‑back).',
+          'Plan de gestión del cambio alineado al marco ético colombiano.'
+        ]
+      },
+      {
+        heading: 'Cómo se vende',
+        points: [
+          'Pack PyME: COP 9,5 M – incluye 5 procesos críticos.',
+          'Corporate: COP 35 M – hasta 20 procesos y workshops para C‑level.'
+        ]
+      }
+    ]
+  },
+  'co-pilot-ai': {
+    title: 'Co‑Pilot AI — Consultoría estratégica, gobierno y capacitación 70‑20‑10',
+    summary:
+      'Acompañamiento continuo de 3 a 12 meses para convertir la hoja de ruta en capacidad interna.',
+    sections: [
+      {
+        heading: 'Módulos clave',
+        points: [
+          'Arquitectura & Integración: latencia ↓30%, errores de datos ↓40%.',
+          'Gobernanza & Ética: políticas de datos y cumplimiento CONPES‑IA.',
+          'Upskilling 70‑20‑10: talleres hands‑on, mentoring y micro‑lecciones.'
+        ]
+      },
+      {
+        heading: 'Elementos diferenciadores',
+        points: [
+          'Contenido sectorial para facilitar la adopción.',
+          'Comunidad de práctica con retos mensuales y office hours.',
+          'OKR de éxito compartidos firmados con el cliente.'
+        ]
+      }
+    ]
+  },
+  'sprint-ia-90': {
+    title: 'Sprint‑IA 90 — Diseño e implementación de pilotos “ROI‑Rápido”',
+    summary:
+      'Desarrollo de 1‑3 pilotos listos para producción en 90 días combinando RPA, IA generativa y analítica predictiva.',
+    sections: [
+      {
+        heading: 'Verticales pre‑empaquetados',
+        points: [
+          'Atención al cliente: chatbot multicanal con hand‑off a humano.',
+          'Cadena de suministro: predicción de demanda e inventario dinámico.',
+          'Ciberseguridad: detección de anomalías en tiempo real.'
+        ]
+      },
+      {
+        heading: 'Metodología',
+        points: [
+          'Design Thinking + Lean AI para prototipo en 2 semanas.',
+          'MVP operativo en sandbox seguro con usuarios reales.',
+          'Escalamiento en la infraestructura del cliente o IA‑as‑a‑Service.'
+        ]
+      },
+      {
+        heading: 'Garantías',
+        points: [
+          'KPI acordado o continuamos sin costo hasta alcanzarlo.',
+          'Transferencia de conocimiento para el equipo interno.'
+        ]
+      }
+    ]
+  }
+};
+
+const ServicePage: React.FC = () => {
+  const { serviceId } = useParams<{ serviceId: string }>();
+  const navigate = useNavigate();
+
+  const { common, servicePage } = useText();
+  const service = serviceId ? SERVICES[serviceId] : undefined;
+
+  if (!service) {
+    return (
+      <div className="py-20 text-center text-text-secondary">
+        {servicePage.notFound}
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-12">
+      <button
+        onClick={() => navigate('/#services')}
+        className="flex items-center gap-2 text-text-tertiary hover:text-purple-primary transition-colors mb-8 group"
+      >
+        <ArrowLeft className="w-5 h-5 transform group-hover:-translate-x-1 transition-transform" />
+        {common.backHome}
+      </button>
+
+      <h1 className="text-4xl font-bold text-text-primary mb-6">{service.title}</h1>
+      <p className="text-text-secondary mb-8">{service.summary}</p>
+
+      {service.sections.map((section, idx) => (
+        <Card key={idx} className="p-6 mb-6">
+          <h2 className="text-2xl font-bold mb-4">{section.heading}</h2>
+          <ul className="list-disc list-inside space-y-2 text-text-secondary">
+            {section.points.map((point, i) => (
+              <li key={i}>{point}</li>
+            ))}
+          </ul>
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+export default ServicePage;


### PR DESCRIPTION
## Summary
- add translation keys for service page not-found message
- expose the new key via `useText`
- use translated message in `ServicePage`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_682cb77c3cc4832cb6117ec7b29f50a9