### PR TITLE
Add login link in navbar

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -71,6 +71,7 @@ const Navbar: React.FC = () => {
               {t('nav_contact')}
             </button>
             <button onClick={() => navigate('/blog')} className="nav-link">{t('nav_blog')}</button>
+            <button onClick={() => navigate('/auth')} className="nav-link">{t('nav_login')}</button>
           </div>
           <div className="ml-2 w-16">
             <CustomSelect value={i18n.language} onChange={changeLanguage} />
@@ -114,6 +115,9 @@ const Navbar: React.FC = () => {
             </button>
             <Link to="/blog" className="nav-link text-lg" onClick={() => setIsMobileMenuOpen(false)}>
               {t('nav_blog')}
+            </Link>
+            <Link to="/auth" className="nav-link text-lg" onClick={() => setIsMobileMenuOpen(false)}>
+              {t('nav_login')}
             </Link>
             
             <CustomSelect value={i18n.language} onChange={changeLanguage} />

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -35,6 +35,7 @@
   "nav_contact": "Contact",
   "nav_blog": "Blog",
   "nav_cta": "Get Started",
+  "nav_login": "Login",
   "landingPage.title": "AI Consulting Colombia | ROI in AI | Husai",
   "landingPage.description": "Transform your company in Colombia with AI. Husai offers AI 360° diagnostics, Co-Pilot AI, and Sprint-IA 90 for fast ROI. We are your strategic allies in AI adoption.",
   "landingPage.keywords": "artificial intelligence Colombia, AI consulting companies, AI business diagnostics, process automation Colombia, generative AI in Spanish, ethical AI adoption, AI for SMEs Colombia, Sprint IA 90 days, data and talent AI strategy, digital transformation 2025, fast AI use cases, ROI artificial intelligence",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -35,6 +35,7 @@
     "nav_contact": "Contacto",
     "nav_blog": "Blog",
     "nav_cta": "Comenzar",
+    "nav_login": "Iniciar sesión",
     "landingPage.title": "Consultoría Inteligencia Artificial Colombia | ROI en IA | Husai",
     "landingPage.description": "Transforme su empresa en Colombia con IA. Husai ofrece diagnóstico IA 360°, Co-Pilot AI y Sprint-IA 90 para ROI rápido. Somos sus aliados estratégicos en adopción de IA.",
     "landingPage.keywords": "inteligencia artificial Colombia, consultoría IA empresas, diagnóstico IA empresarial, automatización procesos Colombia, IA generativa en español, adopción ética de IA, IA para PyMEs Colombia, Sprint IA 90 días, estrategia datos y talento IA",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -35,6 +35,7 @@
     "nav_contact": "Contact",
     "nav_blog": "Blog",
     "nav_cta": "Commencer",
+    "nav_login": "Se connecter",
     "landingPage.title": "AI Consulting Colombia | ROI in AI | Husai",
     "landingPage.description": "Transform your company in Colombia with AI. Husai offers AI 360° diagnostics, Co-Pilot AI, and Sprint-IA 90 for fast ROI. We are your strategic allies in AI adoption.",
     "landingPage.keywords": "artificial intelligence Colombia, AI consulting companies, AI business diagnostics, process automation Colombia, generative AI in Spanish, ethical AI adoption, AI for SMEs Colombia, Sprint IA 90 days, data and talent AI strategy, digital transformation 2025, fast AI use cases, ROI artificial intelligence",


### PR DESCRIPTION
## Summary
- add Login button in desktop and mobile navbar
- close mobile menu when navigating to login
- include translation strings for Login in English, Spanish and French

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_b_68655f3737b4832c892d280dfd02c2ba